### PR TITLE
feat: `formatNumber` helper

### DIFF
--- a/src/components/Content.tsx
+++ b/src/components/Content.tsx
@@ -12,6 +12,7 @@ import Footer from './Footer';
 import { useState, useRef, useEffect } from 'react';
 import Layout from './Layout';
 import PageHeading from './PageHeading';
+import { formatNumber } from '../utils/format';
 
 const Content = () => {
   const [activeTab, setActiveTab] = useState<'deposit' | 'withdraw'>('deposit');
@@ -167,7 +168,7 @@ const Content = () => {
                   {isMetricsLoading ? (
                     <Shimmer height="28px" width="100px" />
                   ) : (
-                    `$${poolBalanceForDisplay ?? '0'}`
+                    `$${formatNumber(poolBalanceForDisplay)}`
                   )}
                 </div>
                 <div className="text-gray-500 text-xs">USDC</div>
@@ -185,7 +186,7 @@ const Content = () => {
                   {isMetricsLoading ? (
                     <Shimmer height="28px" width="100px" />
                   ) : (
-                    `$${awaitingSettlementForDisplay ?? '0'}`
+                    `$${formatNumber(awaitingSettlementForDisplay)}`
                   )}
                 </div>
                 <div className="text-gray-500 text-xs">USDC</div>
@@ -203,7 +204,7 @@ const Content = () => {
                   {isMetricsLoading ? (
                     <Shimmer height="28px" width="100px" />
                   ) : (
-                    `$${poolFeesForDisplay ?? '0'}`
+                    `$${formatNumber(poolFeesForDisplay)}`
                   )}
                 </div>
                 <div className="text-gray-500 text-xs">USDC</div>
@@ -265,7 +266,7 @@ const Content = () => {
                         {isPoolShareLoading ? (
                           <Shimmer height="21px" width="80px" />
                         ) : (
-                          `$${stringifyValue(maxAvailableToWithdraw ?? 0n, 'nat', 6, 4)}`
+                          `$${formatNumber(stringifyValue(maxAvailableToWithdraw ?? 0n, 'nat', 6, 4))}`
                         )}
                       </span>
                     </td>

--- a/src/components/Deposit.tsx
+++ b/src/components/Deposit.tsx
@@ -7,6 +7,7 @@ import { divideBy } from '@agoric/zoe/src/contractSupport/ratio';
 import { toast } from 'react-toastify';
 import { Oval } from 'react-loader-spinner';
 import Shimmer from './Shimmer';
+import { formatNumber } from '../utils/format';
 
 interface Props {
   shareWorth: ReturnType<typeof makeRatio> | undefined;
@@ -155,7 +156,7 @@ const Deposit = ({ shareWorth, showMaxButton = false }: Props) => {
                   className="inline-block align-middle ml-1 -mt-[2px]"
                 />
               ) : (
-                <>{stringifyValue(usdcBalance, 'nat', 6)} USDC</>
+                <>{formatNumber(stringifyValue(usdcBalance, 'nat', 6))} USDC</>
               )}
             </>
           )}

--- a/src/components/Withdraw.tsx
+++ b/src/components/Withdraw.tsx
@@ -7,6 +7,7 @@ import { toast } from 'react-toastify';
 import { divideBy } from '@agoric/zoe/src/contractSupport/ratio';
 import { Oval } from 'react-loader-spinner';
 import Shimmer from './Shimmer';
+import { formatNumber } from '../utils/format';
 
 type Props = {
   availableToWithdraw: bigint | null;
@@ -164,7 +165,12 @@ const Withdraw = ({
                   className="inline-block align-middle ml-1 -mt-[2px]"
                 />
               ) : (
-                <>{stringifyValue(availableToWithdraw || 0n, 'nat', 6)} USDC</>
+                <>
+                  {formatNumber(
+                    stringifyValue(availableToWithdraw || 0n, 'nat', 6),
+                  )}{' '}
+                  USDC
+                </>
               )}
             </>
           )}

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,11 @@
+/**
+ * Uses Intl.NumberFormat style='decimal' to add thousands separator to a
+ * displayed number
+ *
+ * @param value
+ */
+export const formatNumber = new Intl.NumberFormat(undefined, {
+  style: 'decimal',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 4,
+}).format as (value: string | number | bigint | null) => string;


### PR DESCRIPTION
- feat: `formatNumber` helper
  - includes thousands separator in displayed numbers
  - does not account for form inputs (deposit/withdraw)